### PR TITLE
EditProp: Don't change spaces in underscores

### DIFF
--- a/src/com/android/purenexussettings/EditPropFragment.java
+++ b/src/com/android/purenexussettings/EditPropFragment.java
@@ -61,7 +61,7 @@ public class EditPropFragment extends Fragment {
             this.context = context;
             mOrigName = origname == null ? origname : origname.replaceAll(" ", "_");
             mNewName = newname == null ? newname : newname.replaceAll(" ", "_");
-            mNewKey = newkey == null ? newkey : newkey.replaceAll(" ", "_");
+            mNewKey = newkey;
             return this;
         }
 


### PR DESCRIPTION
Spaces are valid in property key.
Raw edit in github (**not verified**)
Thank you!
